### PR TITLE
api: force retries in case of HTTPError 429

### DIFF
--- a/pymempool/api.py
+++ b/pymempool/api.py
@@ -20,7 +20,7 @@ class MempoolAPI:
             warnings.filterwarnings('ignore', message='Unverified HTTPS request')
         self.session = requests.Session()
         retries = urllib3.util.retry.Retry(
-            total=retries, backoff_factor=0.5, status_forcelist=[502, 503, 504]
+            total=retries, backoff_factor=0.5, status_forcelist=[502, 503, 504, 429]
         )
         self.session.mount('https://', HTTPAdapter(max_retries=retries))
 


### PR DESCRIPTION
After approximately 125 requests in a loop, an error occurs. Because of this, I have added Error Code 429 to the force list.